### PR TITLE
add run.sh to run from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Java Application (java 1.8)
 MAC: start with java -XstartOnFirstThread -jar cutImage.jar from jar-directory.
 Selection of image or image-directory for cut more images, define prefix for tiles name and size for tile (default: 256)
 
+You can run this command from the projects root directory by executing:
+
+`bin/run.sh`
+
 Eclipse Project
 ------------
 Luna with java 1.8

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,0 +1,1 @@
+java -XstartOnFirstThread -jar cutImageJar/cutImage.jar


### PR DESCRIPTION
On OSX it was necessary to start the jar with a very specific command.
To ease the use a shell script was added at bin/run.sh that if executed
form the projects root directory will call the right command.
